### PR TITLE
idb2pat infinite loop if function size < 32

### DIFF
--- a/python/flare/idb2pat.py
+++ b/python/flare/idb2pat.py
@@ -258,7 +258,7 @@ def make_func_sig(config, func):
     loc = 32
     crc_data = [0 for i in zrange(256)]
     # for 255 bytes starting at index 32, or til end of function, or variable byte
-    for i in zrange(32, min(func.endEA - func.startEA, 255 + 32)):
+    for i in zrange(32, 32 + min(func.endEA - func.startEA, 255)):
         if i in variable_bytes:
             break
 


### PR DESCRIPTION
`func.endEA - func.startEA` can be less than 32, in which case `zrange` loops infinitely since the sentinel value in `iter` will never be reached. Happened when I used this on an ARM binary. 

To stop this from biting others, two options come to mind: either return `[]` when `end < start` in `zrange` (modeling behavior like `range(32,16)` and `list(xrange(32,16))`), or fail hard with an error. The latter might be the better choice since violations of the `start >= end` invariant should probably debugged, based on how you're using `zrange`.