### PR TITLE
Removing duplicate of crc32 (i.e. playWith0xedb88320Hash)

### DIFF
--- a/shellcode_hashes/make_sc_hash_db.py
+++ b/shellcode_hashes/make_sc_hash_db.py
@@ -448,32 +448,6 @@ for c in input_string {
 }
 '''
 
-def playWith0xedb88320Hash(inString,fName):
-    esi = 0xFFFFFFFF
-    for d in inString:
-        c = ord(d)
-        for i in range(8):
-            eax = c
-            eax ^= esi
-            b0  = eax & 0xFF
-            b0 &= 0x01
-            b0  = -b0
-            if b0 % 2 == 0: # sbb eax, eax
-                eax = 0
-            else:
-                eax = 0xFFFFFFFF
-            eax &= 0xedb88320
-            esi >>= 1
-            esi ^= eax
-            c >>= 1
-    return esi ^ 0xFFFFFFFF
-
-pseudocode_playWith0xedb88320Hash = \
-'''Too hard to explain, AND's with 0xedb88320, though.
-String hash function from Gatak sample.
-See code for information'''
-
-
 def crc32(inString,fName):
     return 0xffffffff & (zlib.crc32(inString))
 
@@ -663,7 +637,6 @@ HASH_TYPES = [
     ('ror13AddHash32Sub1',      32, pseudocode_ror13AddHash32),
     ('shl7shr19Hash32',         32, pseudocode_shl7shr19Hash32),
     ('sll1AddHash32',           32, pseudocode_sll1AddHash32),
-    ('playWith0xedb88320Hash',  32, pseudocode_playWith0xedb88320Hash),
     ('crc32',                   32, 'Standard crc32'),
     ('mult21AddHash32',         32, pseudocode_hashMult21),
     ('add1505Shl5Hash32',       32, pseudocode_add1505Shl5Hash32),


### PR DESCRIPTION
This change retires `playWith0xedb88320Hash` because it duplicates the well-known `crc32` algorithm. Below is a demonstration.

As is the case with the other pull request I made (the one that renames a hash algorithm), the maintainer will want to delete `sc_hashes.db` before generating the shellcode database after _retiring_ this hash algorithm; otherwise, the `playWith0xedb88320Hash` entries will remain in the SQLite database taking up all that extra space, and the algorithm we are trying to retire will still appear in the script dialog.

Hash algorithms `playWith0xedb88320Hash` and `crc32` have IDs 15 and 16 respectively in my copy of `sc_hashes.db`:
```
sqlite> SELECT hash_type, hash_name  FROM hash_types WHERE hash_type in (15, 16);
15|playWith0xedb88320Hash
16|crc32
```

`sqlite3` indicates there are not any rows having a symbol hash mismatch between these two algorithms (the prompt reappears with no intervening output):
```
sqlite> SELECT DISTINCT A.hash_val
   ...> FROM
   ...>     symbol_hashes A
   ...>     INNER JOIN symbol_hashes B
   ...>         ON A.hash_type = 15 AND B.hash_type = 16 AND A.symbol_name = B.symbol_name
   ...> WHERE
   ...>     A.hash_val <> B.hash_val;
sqlite>
```
