### PR TITLE
idb2pat: fix wrong variable preventing to calculare CRC16 and tail bytes

### DIFF
--- a/python/flare/idb2pat.py
+++ b/python/flare/idb2pat.py
@@ -257,11 +257,10 @@ def make_func_sig(config, func):
 
     sig += ".." * (32 - (len(sig) / 2))
 
-    loc = 32
     crc_data = [0 for i in zrange(256)]
     # for 255 bytes starting at index 32, or til end of function, or variable byte
-    for i in zrange(32, 32 + min(func.endEA - func.startEA, 255)):
-        if i in variable_bytes:
+    for loc in zrange(32, 32 + min(func.endEA - func.startEA, 256)):
+        if loc in variable_bytes:
             break
 
         crc_data[loc - 32] = get_byte(func.startEA + loc)


### PR DESCRIPTION
Commits 2f0a449 and 21ad641 introduced variable `loc` to act as a pointer while building the pattern.
The loop consuming the CRC bytes uses `i` instead, causing `loc` to always be equal to 32. If `loc==32` then both CRC16 and tail bytes are skipped.