### PR TITLE
fix imul83hAdd

### DIFF
--- a/shellcode_hashes/make_sc_hash_db.py
+++ b/shellcode_hashes/make_sc_hash_db.py
@@ -664,7 +664,7 @@ def imul83hAdd(inString,fName):
     for i in inString:
         val = val * 131
         val += ord(i)
-    val = val & 0x7FFFFFFF
+    val = val & 0xFFFFFFFF
     return val
 
 pseudocode_imul83hAdd = '''acc := 0;


### PR DESCRIPTION
I found a shellcode that some calculates hashes(imul83hAdd algorithm) were wrong.
![image](https://user-images.githubusercontent.com/18203311/70813677-3cb31980-1e0d-11ea-80e2-62d3305542e1.png)

For example, the first line is a hash of GetProcAddress.
The correct value is "9AB9B854h", However it was "0x1ab9b854" in the script calculation.

I modified the code to get the correct results.
![4](https://user-images.githubusercontent.com/18203311/70814145-412c0200-1e0e-11ea-9617-d6ba6c1acced.png)

Here is a sample in the wild to test this request.
https://www.virustotal.com/gui/file/3a0165e7b01aabccb6955b7d118c53f3baf3f4abbee22df6872723aedc3d90d9/detection


